### PR TITLE
Add ids to HTML elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,45 +7,49 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `Styleguide` components ids.
+
 ## [0.7.0] - 2019-10-14
 
 ## [0.6.1] - 2019-10-01
 
-## Changed
+### Changed
 
 - Styles to fit in flex layout
 
 ## [0.6.0] - 2019-09-20
 
-## Changed
+### Changed
 
 - Summary components to be store blocks
 
 ## [0.5.0] - 2019-09-09
 
-## Added
+### Added
 
 - Tax totalizer translations
 
-## Changed
+### Changed
 
 - FormattedMessage instead of intl
 
 ## [0.4.1] - 2019-09-06
 
-## Added
+### Added
 
 - Summary and Checkout entries in intl list
 
 ## [0.4.0] - 2019-08-29
 
-## Added
+### Added
 
 - Price component in order to show message "free" instead of zero
 
 ## [0.3.0] - 2019-08-26
 
-## Added
+### Added
 
 - Discounts internationalization
 
@@ -57,14 +61,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.2.0] - 2019-08-19
 
-## Changed
+### Changed
 
 - Totalizers prop as an array of Totalizer objects
 - Default values to props
 
 ## [0.1.0] - 2019-08-15
 
-## Added
+### Added
 
 - React component for summary
 - Extension point in order to render Coupon app

--- a/messages/context.json
+++ b/messages/context.json
@@ -1,9 +1,0 @@
-{
-  "store/checkout-summary.Checkout": "Checkout",
-  "store/checkout-summary.Discounts": "Discounts",
-  "store/checkout-summary.Tax": "Taxes",
-  "store/checkout-summary.Items": "Subtotal",
-  "store/checkout-summary.Shipping": "Delivery",
-  "store/checkout-summary.Summary": "Summary",
-  "store/checkout-summary.Total": "Total"
-}

--- a/react/Summary.tsx
+++ b/react/Summary.tsx
@@ -4,14 +4,7 @@ import React, {
   ReactNode,
   useContext,
 } from 'react'
-import { FormattedMessage, defineMessages } from 'react-intl'
-
-defineMessages({
-  summary: {
-    defaultMessage: 'Summary',
-    id: 'store/checkout-summary.Summary',
-  },
-})
+import { FormattedMessage } from 'react-intl'
 
 interface Context {
   totalizers: any[]

--- a/react/SummaryGoToCheckoutButton.tsx
+++ b/react/SummaryGoToCheckoutButton.tsx
@@ -1,17 +1,16 @@
 import React, { FunctionComponent } from 'react'
-import { FormattedMessage, defineMessages } from 'react-intl'
+import { FormattedMessage } from 'react-intl'
 import { Button } from 'vtex.styleguide'
-
-defineMessages({
-  checkout: {
-    defaultMessage: 'Checkout',
-    id: 'store/checkout-summary.Checkout',
-  },
-})
 
 const SummaryGoToCheckoutButton: FunctionComponent<ButtonProps> = () => {
   return (
-    <Button href="/checkout/#payment" variation="primary" size="large" block>
+    <Button
+      id="go-to-checkout"
+      href="/checkout/#payment"
+      variation="primary"
+      size="large"
+      block
+    >
       <FormattedMessage id="store/checkout-summary.Checkout" />
     </Button>
   )

--- a/react/components/SummaryItem.tsx
+++ b/react/components/SummaryItem.tsx
@@ -1,10 +1,5 @@
 import React, { FunctionComponent } from 'react'
-import {
-  defineMessages,
-  injectIntl,
-  InjectedIntlProps,
-  FormattedMessage,
-} from 'react-intl'
+import { defineMessages, FormattedMessage } from 'react-intl'
 import { FormattedPrice } from 'vtex.formatted-price'
 
 defineMessages({
@@ -37,7 +32,7 @@ interface Props {
   value: number
 }
 
-const SummaryItem: FunctionComponent<Props & InjectedIntlProps> = ({
+const SummaryItem: FunctionComponent<Props> = ({
   label,
   name,
   large,
@@ -48,18 +43,17 @@ const SummaryItem: FunctionComponent<Props & InjectedIntlProps> = ({
       large ? 'f4 mt4 pb6' : 'mt3'
     }`}
   >
-    <div className="flex-none fw6 fw5-l">
+    <div id={label} className="flex-none fw6 fw5-l">
       {name ||
         (label && <FormattedMessage id={`store/checkout-summary.${label}`} />)}
     </div>
-    <div
-      className={`flex-auto tr ${large ? 'fw6 fw5-l' : ''} ${
-        value === 0 ? 'c-success' : ''
-      }`}
-    >
-      <FormattedPrice value={value ? value / 100 : value}></FormattedPrice>
+    <div className={`flex-auto tr ${large ? 'fw6 fw5-l' : ''}`}>
+      <FormattedPrice
+        id={`${label}-price`}
+        value={value ? value / 100 : value}
+      ></FormattedPrice>
     </div>
   </div>
 )
 
-export default injectIntl(SummaryItem)
+export default SummaryItem


### PR DESCRIPTION
#### What problem is this solving?

In order to do the e2e tests, the elements need to have identifiers.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://testid--vtexgame1.myvtex.com/cart)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/24034/adicionar-atributo-testid-em-elementos-da-ui)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
