### PR TITLE
Add preview skeleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Preview skeleton.
+- `flex-layout` to coupon's block.
+
 ## [0.9.0] - 2019-11-06
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,8 @@
     "vtex.coupon": "0.x",
     "vtex.format-currency": "0.x",
     "vtex.order-coupon": "0.x",
-    "vtex.formatted-price": "0.x"
+    "vtex.formatted-price": "0.x",
+    "vtex.flex-layout": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/Summary.tsx
+++ b/react/Summary.tsx
@@ -26,6 +26,7 @@ const Summary: FunctionComponent<SummaryProps> = ({
 }
 
 interface SummaryProps {
+  loading: boolean
   totalizers: Totalizer[]
   total: number
 }

--- a/react/Summary.tsx
+++ b/react/Summary.tsx
@@ -5,11 +5,16 @@ import SummaryContextProvider from './SummaryContext'
 
 const Summary: FunctionComponent<SummaryProps> = ({
   children,
+  loading,
   totalizers,
   total,
 }) => {
   return (
-    <SummaryContextProvider totalizers={totalizers} total={total}>
+    <SummaryContextProvider
+      loading={loading}
+      totalizers={totalizers}
+      total={total}
+    >
       <div>
         <h5 className="t-heading-5 mt0 mb5">
           <FormattedMessage id="store/checkout-summary.Summary" />

--- a/react/SummaryContext.tsx
+++ b/react/SummaryContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, FunctionComponent } from 'react'
 
 interface ContextProps {
+  loading: boolean
   totalizers: Totalizer[]
   total: number
 }
@@ -17,11 +18,12 @@ export const useSummary = () => {
 }
 
 const SummaryContextProvider: FunctionComponent<ContextProps> = ({
+  loading,
   totalizers,
   total,
   children,
 }) => (
-  <SummaryContext.Provider value={{ totalizers, total }}>
+  <SummaryContext.Provider value={{ loading, totalizers, total }}>
     {children}
   </SummaryContext.Provider>
 )

--- a/react/SummaryCoupon.tsx
+++ b/react/SummaryCoupon.tsx
@@ -1,9 +1,16 @@
 import React, { FunctionComponent } from 'react'
-import { ExtensionPoint } from 'vtex.render-runtime'
+import { ExtensionPoint, Loading } from 'vtex.render-runtime'
 
 import { OrderCouponProvider } from 'vtex.order-coupon/OrderCoupon'
+import { useSummary } from './SummaryContext'
 
 const SummaryCoupon: FunctionComponent<SummaryCouponProps> = () => {
+  const { loading } = useSummary()
+
+  if (loading) {
+    return <Loading />
+  }
+
   return (
     <OrderCouponProvider>
       <ExtensionPoint id="coupon" />

--- a/react/SummarySmall.tsx
+++ b/react/SummarySmall.tsx
@@ -20,7 +20,11 @@ const SummarySmall: FunctionComponent<Props> = ({
   )
 
   return (
-    <SummaryContextProvider totalizers={filteredTotalizers} total={total}>
+    <SummaryContextProvider
+      loading={false}
+      totalizers={filteredTotalizers}
+      total={total}
+    >
       <div className="c-on-base">{children}</div>
       <span className="t-small db mv4">
         <FormattedMessage id="store/checkout-summary.disclaimer" />

--- a/react/SummaryTotalizers.tsx
+++ b/react/SummaryTotalizers.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react'
+import { Loading } from 'vtex.render-runtime'
 import SummaryItem from './components/SummaryItem'
 
 import { useSummary } from './SummaryContext'
@@ -20,7 +21,11 @@ const SummaryTotalizers: FunctionComponent<SummaryTotalizersProps> = ({
   showTotal = true,
   showDeliveryTotal = true,
 }) => {
-  const { totalizers, total } = useSummary()
+  const {loading, totalizers, total } = useSummary()
+
+  if(loading){
+    return <Loading/>
+  }
 
   if (!isShippingPresent(totalizers) && showDeliveryTotal) {
     totalizers.push(shippingData)

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -1,9 +1,13 @@
 {
   "checkout-summary": {
-    "children": [
-      "summary-coupon",
-      "summary-totalizers"
-    ]
+    "children": ["flex-layout.row#summary-coupon", "summary-totalizers"]
+  },
+
+  "flex-layout.row#summary-coupon": {
+    "children": ["summary-coupon"],
+    "props": {
+      "marginBottom": 6
+    }
   },
 
   "summary-coupon": {

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -6,7 +6,7 @@
   "flex-layout.row#summary-coupon": {
     "children": ["summary-coupon"],
     "props": {
-      "marginBottom": 6
+      "marginBottom": 4
     }
   },
 

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -17,10 +17,22 @@
 
   "summary-coupon": {
     "component": "SummaryCoupon",
-    "allowed": ["coupon"]
+    "allowed": ["coupon"],
+    "preview": {
+      "type": "box",
+      "height": 32,
+      "width": 240
+    }
   },
 
   "summary-totalizers": {
-    "component": "SummaryTotalizers"
+    "component": "SummaryTotalizers",
+    "preview": {
+      "type": "text",
+      "height": 108,
+      "horizontalMargin": 0,
+      "lineHeight": 24,
+      "shortLastLine": false
+    }
   }
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -1,7 +1,7 @@
 {
   "checkout-summary": {
     "component": "Summary",
-    "allowed": ["summary-coupon", "summary-title", "summary-totalizers"],
+    "allowed": "*",
     "composition": "children"
   },
 

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -11,10 +11,6 @@
     "composition": "children"
   },
 
-  "summary-title": {
-    "component": "SummaryTitle"
-  },
-
   "summary-coupon": {
     "component": "SummaryCoupon",
     "allowed": ["coupon"],


### PR DESCRIPTION
#### What problem is this solving?

Since the loading spinner was removed from `checkout-cart`, each component now must have its own preview skeleton. This PR adds the summary one.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](url)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/24408/aplicar-o-skeleton-no-carregamento-do-carrinho)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
