### PR TITLE
Create compact version of Summary component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- New `SummarySmall` component and `checkout-summary.compact` interface.
+- New `showTotal` and `showDeliveryTotal` props to `SummaryTotalizers`.
+
 ## [0.8.1] - 2019-10-23
 
 ### Changed

--- a/messages/en.json
+++ b/messages/en.json
@@ -4,5 +4,6 @@
   "store/checkout-summary.Items": "Subtotal",
   "store/checkout-summary.Shipping": "Delivery",
   "store/checkout-summary.Summary": "Summary",
-  "store/checkout-summary.Total": "Total"
+  "store/checkout-summary.Total": "Total",
+  "store/checkout-summary.disclaimer": "Shipping and taxes calculated at checkout."
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -4,5 +4,6 @@
   "store/checkout-summary.Items": "Subtotal",
   "store/checkout-summary.Shipping": "Entrega",
   "store/checkout-summary.Summary": "Resumen",
-  "store/checkout-summary.Total": "Total"
+  "store/checkout-summary.Total": "Total",
+  "store/checkout-summary.disclaimer": "Gastos de envío e impuestos calculados al finalizar la compra."
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -4,5 +4,6 @@
   "store/checkout-summary.Items": "Subtotal",
   "store/checkout-summary.Summary": "Resumo",
   "store/checkout-summary.Shipping": "Entrega",
-  "store/checkout-summary.Total": "Total"
+  "store/checkout-summary.Total": "Total",
+  "store/checkout-summary.disclaimer": "Taxas e frete calculados no checkout"
 }

--- a/react/Summary.tsx
+++ b/react/Summary.tsx
@@ -1,26 +1,7 @@
-import React, {
-  createContext,
-  FunctionComponent,
-  ReactNode,
-  useContext,
-} from 'react'
+import React, { FunctionComponent } from 'react'
 import { FormattedMessage } from 'react-intl'
 
-interface Context {
-  totalizers: any[]
-  total: number
-}
-
-const SummaryContext = createContext<Context | undefined>(undefined)
-
-export const useSummary = () => {
-  const context = useContext(SummaryContext)
-  if (context === undefined) {
-    throw new Error('useSummary must be used within a SummaryProvider')
-  }
-
-  return context
-}
+import SummaryContextProvider from './SummaryContext'
 
 const Summary: FunctionComponent<SummaryProps> = ({
   children,
@@ -28,22 +9,19 @@ const Summary: FunctionComponent<SummaryProps> = ({
   total,
 }) => {
   return (
-    <SummaryContext.Provider value={{ totalizers: totalizers, total: total }}>
+    <SummaryContextProvider totalizers={totalizers} total={total}>
       <div>
         <h5 className="t-heading-5 mt0 mb5">
           <FormattedMessage id="store/checkout-summary.Summary" />
         </h5>
         <div className="c-on-base">{children}</div>
       </div>
-    </SummaryContext.Provider>
+    </SummaryContextProvider>
   )
 }
 
 interface SummaryProps {
-  children: ReactNode
-  title?: string
-  intl: object
-  totalizers: any[]
+  totalizers: Totalizer[]
   total: number
 }
 

--- a/react/SummaryContext.tsx
+++ b/react/SummaryContext.tsx
@@ -1,0 +1,29 @@
+import React, { createContext, useContext, FunctionComponent } from 'react'
+
+interface ContextProps {
+  totalizers: Totalizer[]
+  total: number
+}
+
+const SummaryContext = createContext<ContextProps | undefined>(undefined)
+
+export const useSummary = () => {
+  const context = useContext(SummaryContext)
+  if (context === undefined) {
+    throw new Error('useSummary must be used within a SummaryProvider')
+  }
+
+  return context
+}
+
+const SummaryContextProvider: FunctionComponent<ContextProps> = ({
+  totalizers,
+  total,
+  children,
+}) => (
+  <SummaryContext.Provider value={{ totalizers, total }}>
+    {children}
+  </SummaryContext.Provider>
+)
+
+export default SummaryContextProvider

--- a/react/SummarySmall.tsx
+++ b/react/SummarySmall.tsx
@@ -1,0 +1,32 @@
+import React, { FunctionComponent } from 'react'
+import { FormattedMessage } from 'react-intl'
+
+import SummaryContextProvider from './SummaryContext'
+
+interface Props {
+  totalizers: Totalizer[]
+  total: number
+  totalizersToShow: string[]
+}
+
+const SummarySmall: FunctionComponent<Props> = ({
+  total,
+  children,
+  totalizers,
+  totalizersToShow = ['Items'],
+}) => {
+  const filteredTotalizers = totalizers.filter(totalizer =>
+    totalizersToShow.includes(totalizer.id)
+  )
+
+  return (
+    <SummaryContextProvider totalizers={filteredTotalizers} total={total}>
+      <div className="c-on-base">{children}</div>
+      <span className="t-small db mv4">
+        <FormattedMessage id="store/checkout-summary.disclaimer" />
+      </span>
+    </SummaryContextProvider>
+  )
+}
+
+export default SummarySmall

--- a/react/SummaryTotalizers.tsx
+++ b/react/SummaryTotalizers.tsx
@@ -1,10 +1,10 @@
 import React, { FunctionComponent } from 'react'
 import SummaryItem from './components/SummaryItem'
 
-import { useSummary } from './Summary'
+import { useSummary } from './SummaryContext'
 
 const minTotalizerValue = 0
-const tba = undefined
+const tba = null
 const shippingData = {
   id: 'Shipping',
   name: '',
@@ -16,10 +16,13 @@ const isShippingPresent = (totalizers: Totalizer[]) => {
   return totalizers.some(t => t.id === 'Shipping')
 }
 
-const SummaryTotalizers: FunctionComponent<SummaryTotalizersProps> = () => {
+const SummaryTotalizers: FunctionComponent<SummaryTotalizersProps> = ({
+  showTotal = true,
+  showDeliveryTotal = true,
+}) => {
   const { totalizers, total } = useSummary()
 
-  if (!isShippingPresent(totalizers)) {
+  if (!isShippingPresent(totalizers) && showDeliveryTotal) {
     totalizers.push(shippingData)
   }
 
@@ -35,20 +38,20 @@ const SummaryTotalizers: FunctionComponent<SummaryTotalizersProps> = () => {
         />
       ))}
 
-      <SummaryItem
-        label="Total"
-        value={total ? total : minTotalizerValue}
-        large
-      />
+      {showTotal && (
+        <SummaryItem
+          label="Total"
+          value={total ? total : minTotalizerValue}
+          large
+        />
+      )}
     </div>
   )
 }
 
-interface SummaryTotalizersProps {}
-
-SummaryTotalizers.defaultProps = {
-  totalizers: [],
-  total: minTotalizerValue,
+interface SummaryTotalizersProps {
+  showTotal: boolean
+  showDeliveryTotal: boolean
 }
 
 export default SummaryTotalizers

--- a/react/components/SummaryItem.tsx
+++ b/react/components/SummaryItem.tsx
@@ -31,7 +31,7 @@ interface Props {
   label: string
   name?: string
   large: boolean
-  value: number
+  value: number | null
 }
 
 const SummaryItem: FunctionComponent<Props> = ({

--- a/react/typings/globals.d.ts
+++ b/react/typings/globals.d.ts
@@ -1,5 +1,5 @@
 interface Totalizer {
   id: string
-  value: number
+  value: number | null
   name: string
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -1,11 +1,13 @@
 {
   "checkout-summary": {
     "component": "Summary",
-    "allowed": [
-      "summary-coupon",
-      "summary-title",
-      "summary-totalizers"
-    ],
+    "allowed": ["summary-coupon", "summary-title", "summary-totalizers"],
+    "composition": "children"
+  },
+
+  "checkout-summary.compact": {
+    "component": "SummarySmall",
+    "allowed": ["summary-totalizers"],
     "composition": "children"
   },
 


### PR DESCRIPTION
#### What problem is this solving?

 - This creates a new interface `checkout-summary.compact` that renders a smaller version of  `checkout-summary`, especially useful for the `minicart`, where it is not necessary to display every totalizer from `OrderForm`.
- Also, adding new props to `SummaryTotalizers` to control whether or not to display the total order value and shipping value, which is often not even calculated while the user is using the `minicart`.

#### How should this be manually tested?

This workspace has the new `minicart` linked to it, using `checkout-summary.compact`:
[Workspace](https://minicart--storecomponents.myvtex.com/)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
