### PR TITLE
Add necessary coupon data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - The necessary `checkout-coupon` data.
 
+### Changed
+
+- Store interfaces `preview` props.
+
 ## [0.10.0] - 2019-11-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- The necessary `checkout-coupon` data.
+
 ## [0.10.0] - 2019-11-06
 
 ### Added

--- a/react/Summary.tsx
+++ b/react/Summary.tsx
@@ -8,9 +8,15 @@ const Summary: FunctionComponent<SummaryProps> = ({
   loading,
   totalizers,
   total,
+  coupon,
+  couponErrorKey,
+  insertCoupon,
 }) => {
   return (
     <SummaryContextProvider
+      coupon={coupon}
+      insertCoupon={insertCoupon}
+      couponErrorKey={couponErrorKey}
       loading={loading}
       totalizers={totalizers}
       total={total}
@@ -26,6 +32,9 @@ const Summary: FunctionComponent<SummaryProps> = ({
 }
 
 interface SummaryProps {
+  coupon: string
+  insertCoupon: (coupon: string) => Promise<boolean>
+  couponErrorKey: string
   loading: boolean
   totalizers: Totalizer[]
   total: number

--- a/react/Summary.tsx
+++ b/react/Summary.tsx
@@ -31,11 +31,11 @@ const Summary: FunctionComponent<SummaryProps> = ({
   )
 }
 
-interface SummaryProps {
-  coupon: string
-  insertCoupon: (coupon: string) => Promise<boolean>
-  couponErrorKey: string
-  loading: boolean
+export interface SummaryProps {
+  coupon?: string
+  insertCoupon?: (coupon: string) => Promise<boolean>
+  couponErrorKey?: string
+  loading?: boolean
   totalizers: Totalizer[]
   total: number
 }

--- a/react/SummaryContext.tsx
+++ b/react/SummaryContext.tsx
@@ -1,7 +1,10 @@
 import React, { createContext, useContext, FunctionComponent } from 'react'
 
 interface ContextProps {
-  loading: boolean
+  coupon?: string
+  insertCoupon?: (coupon: string) => Promise<boolean>
+  couponErrorKey?: string
+  loading?: boolean
   totalizers: Totalizer[]
   total: number
 }
@@ -18,12 +21,24 @@ export const useSummary = () => {
 }
 
 const SummaryContextProvider: FunctionComponent<ContextProps> = ({
+  coupon,
+  insertCoupon,
+  couponErrorKey,
   loading,
   totalizers,
   total,
   children,
 }) => (
-  <SummaryContext.Provider value={{ loading, totalizers, total }}>
+  <SummaryContext.Provider
+    value={{
+      coupon,
+      insertCoupon,
+      couponErrorKey,
+      loading,
+      totalizers,
+      total,
+    }}
+  >
     {children}
   </SummaryContext.Provider>
 )

--- a/react/SummaryContext.tsx
+++ b/react/SummaryContext.tsx
@@ -1,15 +1,8 @@
 import React, { createContext, useContext, FunctionComponent } from 'react'
 
-interface ContextProps {
-  coupon?: string
-  insertCoupon?: (coupon: string) => Promise<boolean>
-  couponErrorKey?: string
-  loading?: boolean
-  totalizers: Totalizer[]
-  total: number
-}
+import { SummaryProps } from './Summary'
 
-const SummaryContext = createContext<ContextProps | undefined>(undefined)
+const SummaryContext = createContext<SummaryProps | undefined>(undefined)
 
 export const useSummary = () => {
   const context = useContext(SummaryContext)
@@ -20,7 +13,7 @@ export const useSummary = () => {
   return context
 }
 
-const SummaryContextProvider: FunctionComponent<ContextProps> = ({
+const SummaryContextProvider: FunctionComponent<SummaryProps> = ({
   coupon,
   insertCoupon,
   couponErrorKey,

--- a/react/SummaryCoupon.tsx
+++ b/react/SummaryCoupon.tsx
@@ -5,7 +5,7 @@ import { OrderCouponProvider } from 'vtex.order-coupon/OrderCoupon'
 import { useSummary } from './SummaryContext'
 
 const SummaryCoupon: FunctionComponent<SummaryCouponProps> = () => {
-  const { loading } = useSummary()
+  const { coupon, insertCoupon, couponErrorKey, loading } = useSummary()
 
   if (loading) {
     return <Loading />
@@ -13,7 +13,12 @@ const SummaryCoupon: FunctionComponent<SummaryCouponProps> = () => {
 
   return (
     <OrderCouponProvider>
-      <ExtensionPoint id="coupon" />
+      <ExtensionPoint
+        id="coupon"
+        coupon={coupon}
+        insertCoupon={insertCoupon}
+        couponErrorKey={couponErrorKey}
+      />
     </OrderCouponProvider>
   )
 }

--- a/react/SummarySmall.tsx
+++ b/react/SummarySmall.tsx
@@ -20,11 +20,7 @@ const SummarySmall: FunctionComponent<Props> = ({
   )
 
   return (
-    <SummaryContextProvider
-      loading={false}
-      totalizers={filteredTotalizers}
-      total={total}
-    >
+    <SummaryContextProvider totalizers={filteredTotalizers} total={total}>
       <div className="c-on-base">{children}</div>
       <span className="t-small db mv4">
         <FormattedMessage id="store/checkout-summary.disclaimer" />

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -6,7 +6,7 @@
   "flex-layout.row#summary-coupon": {
     "children": ["summary-coupon"],
     "props": {
-      "marginBottom": 4
+      "marginBottom": 6
     }
   },
 

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -17,7 +17,10 @@
     "preview": {
       "type": "box",
       "height": 32,
-      "width": 240
+      "width": 240,
+      "options": {
+        "padding": 0
+      }
     }
   },
 
@@ -26,9 +29,11 @@
     "preview": {
       "type": "text",
       "height": 108,
-      "horizontalMargin": 0,
-      "lineHeight": 24,
-      "shortLastLine": false
+      "options": {
+        "padding": 0,
+        "fontSize": 24,
+        "paragraph": false
+      }
     }
   }
 }


### PR DESCRIPTION
#### What problem is this solving?

As the title says, this PR adds the necessary `checkout-coupon` data.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- Go to [Workspace](https://buttonloading--checkoutio.myvtex.com/cart)
- Try to insert a coupon
- Verify if its working normally.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
