### PR TITLE
Remove couponErrorKey prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- `couponErrorKey` is not being provided as a prop anymore but, instead, it is now part of `insertCoupon` result.
+
 ## [0.11.0] - 2019-11-06
 
 ### Added

--- a/react/Summary.tsx
+++ b/react/Summary.tsx
@@ -9,14 +9,12 @@ const Summary: FunctionComponent<SummaryProps> = ({
   totalizers,
   total,
   coupon,
-  couponErrorKey,
   insertCoupon,
 }) => {
   return (
     <SummaryContextProvider
       coupon={coupon}
       insertCoupon={insertCoupon}
-      couponErrorKey={couponErrorKey}
       loading={loading}
       totalizers={totalizers}
       total={total}
@@ -31,10 +29,14 @@ const Summary: FunctionComponent<SummaryProps> = ({
   )
 }
 
+interface InsertCouponResult {
+  success: boolean
+  errorKey: string
+}
+
 export interface SummaryProps {
   coupon?: string
-  insertCoupon?: (coupon: string) => Promise<boolean>
-  couponErrorKey?: string
+  insertCoupon?: (coupon: string) => Promise<InsertCouponResult>
   loading?: boolean
   totalizers: Totalizer[]
   total: number

--- a/react/SummaryContext.tsx
+++ b/react/SummaryContext.tsx
@@ -16,7 +16,6 @@ export const useSummary = () => {
 const SummaryContextProvider: FunctionComponent<SummaryProps> = ({
   coupon,
   insertCoupon,
-  couponErrorKey,
   loading,
   totalizers,
   total,
@@ -26,7 +25,6 @@ const SummaryContextProvider: FunctionComponent<SummaryProps> = ({
     value={{
       coupon,
       insertCoupon,
-      couponErrorKey,
       loading,
       totalizers,
       total,

--- a/react/SummaryCoupon.tsx
+++ b/react/SummaryCoupon.tsx
@@ -5,7 +5,7 @@ import { OrderCouponProvider } from 'vtex.order-coupon/OrderCoupon'
 import { useSummary } from './SummaryContext'
 
 const SummaryCoupon: FunctionComponent<SummaryCouponProps> = () => {
-  const { coupon, insertCoupon, couponErrorKey, loading } = useSummary()
+  const { coupon, insertCoupon, loading } = useSummary()
 
   if (loading) {
     return <Loading />
@@ -13,12 +13,7 @@ const SummaryCoupon: FunctionComponent<SummaryCouponProps> = () => {
 
   return (
     <OrderCouponProvider>
-      <ExtensionPoint
-        id="coupon"
-        coupon={coupon}
-        insertCoupon={insertCoupon}
-        couponErrorKey={couponErrorKey}
-      />
+      <ExtensionPoint id="coupon" coupon={coupon} insertCoupon={insertCoupon} />
     </OrderCouponProvider>
   )
 }


### PR DESCRIPTION
#### What problem is this solving?

`couponErrorKey` prop is no longer necessary, since its now a part of the `insertCoupon` result. This PR removes it.

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

- Go to [Workspace](https://fixcouponerror--checkoutio.myvtex.com/cart)
- Try to insert a coupon
- Verify its working normally

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
