### PR TITLE
Force summary preview skeleton to use the entire component's width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Forces summary preview skeleton to use the entire component's width.
+
 ## [0.13.0] - 2019-12-03
 
 ### Added

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -32,6 +32,7 @@
     "preview": {
       "type": "text",
       "height": 108,
+      "fullWidth": true,
       "options": {
         "padding": 0,
         "fontSize": 24,


### PR DESCRIPTION
#### What problem is this solving?

As the title says...

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

[Workspace](https://fixskeleton--checkoutio.myvtex.com/cart)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable).](https://app.clubhouse.io/vtex/story/26848/corrigir-skeleton-mobile)
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
