### PR TITLE
Add schema to Summary component so it appears in Site Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `schema` to `Summary` component so it appears in Site Editor.
+
 ## [0.12.0] - 2019-11-14
 
 ### Changed

--- a/messages/en.json
+++ b/messages/en.json
@@ -5,5 +5,7 @@
   "store/checkout-summary.Shipping": "Delivery",
   "store/checkout-summary.Summary": "Summary",
   "store/checkout-summary.Total": "Total",
-  "store/checkout-summary.disclaimer": "Shipping and taxes calculated at checkout."
+  "store/checkout-summary.disclaimer": "Shipping and taxes calculated at checkout.",
+  "admin/editor.checkout-summary.label": "Summary",
+  "admin/editor.checkout-summary.title": "Title"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -5,5 +5,7 @@
   "store/checkout-summary.Shipping": "Entrega",
   "store/checkout-summary.Summary": "Resumen",
   "store/checkout-summary.Total": "Total",
-  "store/checkout-summary.disclaimer": "Gastos de envío e impuestos calculados al finalizar la compra."
+  "store/checkout-summary.disclaimer": "Gastos de envío e impuestos calculados al finalizar la compra.",
+  "admin/editor.checkout-summary.label": "Resumen",
+  "admin/editor.checkout-summary.title": "Título"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -5,5 +5,7 @@
   "store/checkout-summary.Summary": "Resumo",
   "store/checkout-summary.Shipping": "Entrega",
   "store/checkout-summary.Total": "Total",
-  "store/checkout-summary.disclaimer": "Taxas e frete calculados no checkout"
+  "store/checkout-summary.disclaimer": "Taxas e frete calculados no checkout",
+  "admin/editor.checkout-summary.label": "Resumo",
+  "admin/editor.checkout-summary.title": "Título"
 }

--- a/react/Summary.tsx
+++ b/react/Summary.tsx
@@ -1,15 +1,27 @@
-import React, { FunctionComponent } from 'react'
-import { FormattedMessage } from 'react-intl'
+import React from 'react'
+import { defineMessages, FormattedMessage } from 'react-intl'
 
 import SummaryContextProvider from './SummaryContext'
 
-const Summary: FunctionComponent<SummaryProps> = ({
+const messages = defineMessages({
+  label: {
+    id: 'admin/editor.checkout-summary.label',
+    defaultMessage: '',
+  },
+  title: {
+    id: 'store/checkout-summary.Summary',
+    defaultMessage: '',
+  },
+})
+
+const Summary: StorefrontFunctionComponent<StorefrontSummaryProps> = ({
   children,
   loading,
   totalizers,
   total,
   coupon,
   insertCoupon,
+  title,
 }) => {
   return (
     <SummaryContextProvider
@@ -21,7 +33,7 @@ const Summary: FunctionComponent<SummaryProps> = ({
     >
       <div>
         <h5 className="t-heading-5 mt0 mb5">
-          <FormattedMessage id="store/checkout-summary.Summary" />
+          <FormattedMessage id={title} />
         </h5>
         <div className="c-on-base">{children}</div>
       </div>
@@ -40,6 +52,14 @@ export interface SummaryProps {
   loading?: boolean
   totalizers: Totalizer[]
   total: number
+}
+
+interface StorefrontSummaryProps extends SummaryProps {
+  title: string
+}
+
+Summary.schema = {
+  title: messages.label.id,
 }
 
 export default Summary

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -1,0 +1,12 @@
+{
+  "definitions": {
+    "Summary": {
+      "properties": {
+        "title": {
+          "$ref": "app:vtex.native-types#/definitions/text",
+          "default": "store/checkout-summary.Summary"
+        }
+      }
+    }
+  }
+}

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -2,7 +2,10 @@
   "checkout-summary": {
     "component": "Summary",
     "allowed": "*",
-    "composition": "children"
+    "composition": "children",
+    "content": {
+      "$ref": "#/definitions/Summary"
+    }
   },
 
   "checkout-summary.compact": {


### PR DESCRIPTION
#### What problem is this solving?

ATTS.

#### How should this be manually tested?

[Add an item to cart](https://schemas--checkoutio.myvtex.com/cart/add?sku=31&sku=36&sku=33&sku=250&sku=17), then head to the [Site Editor](https://schemas--checkoutio.myvtex.com/admin/cms/site-editor/cart). Try changing the text of the title of the Summary section in Portuguese, and verify those changes are reflected in the other languages.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] [Linked this PR to a Clubhouse story (if applicable)](https://app.clubhouse.io/vtex/story/26707/adicionar-schema-nos-componentes-para-aparecerem-no-site-editor).
- [ ] Updated/created tests (important for bug fixes).
- [x] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/8902498/69674214-bf508080-107a-11ea-94a3-4e4c0eb70f44.png)


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
