### PR TITLE
Add div back to Summary wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Summary layout.
+
 ## [0.14.0] - 2019-12-19
 
 ### Added

--- a/react/Summary.tsx
+++ b/react/Summary.tsx
@@ -36,10 +36,13 @@ const Summary: StorefrontFunctionComponent<StorefrontSummaryProps> = ({
       totalizers={totalizers}
       total={total}
     >
-      <h5 className={`${handles.summaryTitle} t-heading-5 mt0 mb5`}>
-        <FormattedMessage id={title} />
-      </h5>
-      <div className={`${handles.summaryContent} c-on-base`}>{children}</div>
+      {/* Removing the div below may break the layout. See PR #25 */}
+      <div>
+        <h5 className={`${handles.summaryTitle} t-heading-5 mt0 mb5`}>
+          <FormattedMessage id={title} />
+        </h5>
+        <div className={`${handles.summaryContent} c-on-base`}>{children}</div>
+      </div>
     </SummaryContextProvider>
   )
 }


### PR DESCRIPTION
#### What problem is this solving?

The last PR removed a div from the Summary wrapper, which broke the layout because the Summary component is wrapped by a `flex-layout ` container. This resulted in the title and the remaining of the component appearing on the same row. This PR adds the `div` back.

#### How should this be manually tested?

The **summary component** of [this workspace](https://div--checkoutio.myvtex.com/cart) should not be broken.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
