### PR TITLE
Add advanced blocks configuration section to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `Advanced configuration` section in the documentation.
+
 ## [0.14.1] - 2019-12-23
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,31 @@ Compact version:
   }
 ```
 
+### Advanced Customization
+
+The `checkout-summary` block is made up of other smalled blocks. Currently, its default implementation is as follows:
+
+```json
+{
+  "checkout-summary": {
+    "children": ["flex-layout.row#summary-coupon", "summary-totalizers"]
+  },
+  "flex-layout.row#summary-coupon": {
+    "children": ["summary-coupon"],
+    "props": {
+      "marginBottom": 6
+    }
+  },
+  "summary-coupon": {
+    "blocks": ["coupon"]
+  }
+}
+```
+
+By default implementation we mean that whenever you use `checkout-summary` in your store you're actually using the `json` above behind the scenes.
+
+Therefore, in order to customize the Checkout Summary configuration, you can simply use the default implementation in your code and change it as you wish.
+
 ## Customization
 
 In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ Compact version:
 
 ### Advanced Customization
 
-The `checkout-summary` block is made up of other smalled blocks. Currently, its default implementation is as follows:
+The `checkout-summary` block is made up of other smaller blocks. Currently, its default implementation is as follows:
 
 ```json
 {


### PR DESCRIPTION
#### What problem is this solving?

This should help people to understand better how to customize the `checkout-summary` block.

#### How should this be manually tested?

https://github.com/vtex-apps/checkout-summary/tree/feature/advanced-docs/docs

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and the overall reduction of technical debt -->
