### PR TITLE
Enable checkout-summary.compact block to show a total value based on visible totalizers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `totalCalculation` prop to `SummarySmall` component.
+
+### Changed
+- Disclaimer regarding shipping and taxes will only be rendered by `SummarySmall` if the `Shipping` totalizer is not being shown.
 
 ## [0.16.0] - 2020-04-22
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -125,8 +125,9 @@ The component rendered when used the `checkout-summary.compact` block.
 | Prop name | Type | Required |
 | --- | --- | --- |
 | [`totalizers`](#summarysmall-totalizers) | `array` | `true` |
-| [`totalizersToShow`](#summarysmall-totalizerstoshow) | `array` | `true` |
+| [`totalizersToShow`](#summarysmall-totalizersToShow) | `array` | `true` |
 | [`total`](#summarysmall-total) | `number` | `true` |
+| [`totalCalculation`](#summarysmall-totalCalculation) | `enum` | `visibleTotalizers` |
 
 ##### SummarySmall totalizers
 
@@ -137,6 +138,10 @@ Same as the [Summary totalizers](#summary-totalizers) prop.
 ##### SummarySmall total
 
 Same as the [Summary total](#summary-total) prop.
+
+##### SummarySmall totalCalculation
+
+Controls how the `Total` shown in the bottom of the summary is calculated. Possible values are: `visibleTotalizers`, which means that the `Total` shown will only take into account visible totalizers (the ones included in the `totalizersToShow` array), and `allTotalizers`, which will take into account all totalizers from `orderForm`, even if they're not being displayed.
 
 ##### SummarySmall totalizersToShow
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,9 @@
 # Summary
+
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-0-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 The Summary block displays the order totalizers and allows the user to add coupon codes. Currently, the Summary block only works out of the box within the [Minicart](https://github.com/vtex-apps/minicart) and the [Checkout Cart](https://github.com/vtex-apps/checkout-cart).
@@ -93,18 +96,11 @@ Notice the following: the block declared as children of the `drawer-trigger` blo
 ```jsonc
 {
   "checkout-summary": {
-    "blocks": [
-      "drawer#my-drawer"
-    ],
-    "children": [
-      "flex-layout.row#summary-coupon",
-      "summary-totalizers"
-    ]
+    "blocks": ["drawer#my-drawer"],
+    "children": ["flex-layout.row#summary-coupon", "summary-totalizers"]
   },
   "drawer#my-drawer": {
-    "blocks": [
-      "drawer-trigger#my-trigger"
-    ]
+    "blocks": ["drawer-trigger#my-trigger"]
   },
   "drawer-trigger#my-trigger": {
     "children": [
@@ -115,19 +111,18 @@ Notice the following: the block declared as children of the `drawer-trigger` blo
 }
 ```
 
-
 ### SummarySmall
 
 The component rendered when used the `checkout-summary.compact` block.
 
 #### Props
 
-| Prop name | Type | Required |
-| --- | --- | --- |
-| [`totalizers`](#summarysmall-totalizers) | `array` | `true` |
-| [`totalizersToShow`](#summarysmall-totalizersToShow) | `array` | `true` |
-| [`total`](#summarysmall-total) | `number` | `true` |
-| [`totalCalculation`](#summarysmall-totalCalculation) | `enum` | `visibleTotalizers` |
+| Prop name                                            | Type     | Default             |
+| ---------------------------------------------------- | -------- | ------------------- |
+| [`totalizers`](#summarysmall-totalizers)             | `array`  | `undefined`         |
+| [`totalizersToShow`](#summarysmall-totalizersToShow) | `array`  | `['Items']`         |
+| [`total`](#summarysmall-total)                       | `number` | `undefined`         |
+| [`totalCalculation`](#summarysmall-totalCalculation) | `enum`   | `visibleTotalizers` |
 
 ##### SummarySmall totalizers
 
@@ -154,7 +149,7 @@ Id of the totalizers that should be displayed inside this component, e.g.:
   // Value of the subtotal
   'Items',
   // Delivery value
-  'Shipping'
+  'Shipping',
 ]
 ```
 
@@ -181,6 +176,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- markdownlint-disable -->
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind are welcome!

--- a/messages/en.json
+++ b/messages/en.json
@@ -5,7 +5,7 @@
   "store/checkout-summary.Shipping": "Delivery",
   "store/checkout-summary.Summary": "Summary",
   "store/checkout-summary.Total": "Total",
-  "store/checkout-summary.disclaimer": "Shipping and taxes calculated at checkout.",
+  "store/checkout-summary.disclaimer": "Shipping and taxes calculated at the Cart.",
   "admin/editor.checkout-summary.label": "Summary",
   "admin/editor.checkout-summary.title": "Title"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -5,7 +5,7 @@
   "store/checkout-summary.Summary": "Resumo",
   "store/checkout-summary.Shipping": "Entrega",
   "store/checkout-summary.Total": "Total",
-  "store/checkout-summary.disclaimer": "Taxas e frete calculados no checkout",
+  "store/checkout-summary.disclaimer": "Taxas e frete calculados no Carrinho",
   "admin/editor.checkout-summary.label": "Resumo",
   "admin/editor.checkout-summary.title": "Título"
 }

--- a/react/SummarySmall.tsx
+++ b/react/SummarySmall.tsx
@@ -8,6 +8,7 @@ interface Props {
   totalizers: Totalizer[]
   total: number
   totalizersToShow: string[]
+  totalCalculation: 'visibleTotalizers' | 'allTotalizers'
 }
 
 const CSS_HANDLES = ['summarySmallContent', 'summarySmallDisclaimer'] as const
@@ -17,6 +18,7 @@ const SummarySmall: FunctionComponent<Props> = ({
   children,
   totalizers,
   totalizersToShow = ['Items'],
+  totalCalculation = 'visibleTotalizers',
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
 
@@ -24,14 +26,28 @@ const SummarySmall: FunctionComponent<Props> = ({
     totalizersToShow.includes(totalizer.id)
   )
 
+  const totalToDisplay =
+    totalCalculation === 'visibleTotalizers'
+      ? filteredTotalizers.reduce((acc, totalizer) => {
+          return (acc += totalizer.value ?? 0)
+        }, 0)
+      : total
+
+  const shouldDisplayShippingDisclaimer = !totalizersToShow.includes('Shipping')
+
   return (
-    <SummaryContextProvider totalizers={filteredTotalizers} total={total}>
+    <SummaryContextProvider
+      totalizers={filteredTotalizers}
+      total={totalToDisplay}
+    >
       <div className={`${handles.summarySmallContent} c-on-base`}>
         {children}
       </div>
-      <span className={`${handles.summarySmallDisclaimer} t-small db mv4`}>
-        <FormattedMessage id="store/checkout-summary.disclaimer" />
-      </span>
+      {shouldDisplayShippingDisclaimer && (
+        <span className={`${handles.summarySmallDisclaimer} t-small db mv4`}>
+          <FormattedMessage id="store/checkout-summary.disclaimer" />
+        </span>
+      )}
     </SummaryContextProvider>
   )
 }

--- a/react/package.json
+++ b/react/package.json
@@ -21,7 +21,7 @@
     "@types/react-intl": "^2.3.17",
     "@vtex/test-tools": "^3.1.0",
     "apollo-client": "^2.5.1",
-    "typescript": "3.8.3",
+    "typescript": "3.9.7",
     "vtex.coupon": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.coupon@0.10.1/public/@types/vtex.coupon",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles",
     "vtex.flex-layout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.14.0/public/@types/vtex.flex-layout",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5272,10 +5272,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 typescript@^3.7.3:
   version "3.9.6"


### PR DESCRIPTION
#### What problem is this solving?

Currently, the value received by the `totalizersToShow` prop is only taken into account to toggle the visibility of each totalizer, but doesn't have any effect in the `Total` value shown in the `minicart.v2`. This can create weird behaviors, such as this one:

![image](https://user-images.githubusercontent.com/27777263/95917402-97483980-0d80-11eb-9747-49c190fa1a78.png)

In this image, the `Total` is greater than `Subtotal` because it takes into account the `Shipping` price. But since `Shipping` is not in being shown to users, it might be confusing.

To avoid this, we're adding a new `totalCalculation` prop, that enables users to control whether or not the `checkout-summary.compact` should only take into account the visible totalizers to calculate the `Total` displayed to users. 

Also, we'll refrain from showing the `Shipping and taxes calculated at checkout.` disclaimer if the `Shipping` totalizer is already taken into account to show the `Total` price.

#### How to test it?

1. Go to the [master workspace](Link goes here!) and add the `Top Wood Clock` product to the cart. The `minicart.v2` should pop open, and you should see this at the bottom:

![Screen Shot 2020-10-14 at 14 34 26](https://user-images.githubusercontent.com/27777263/96024642-645a8000-0e2a-11eb-91bd-cea7114ce71f.png)

Notice that the `Total` is greater than the `Subtotal`. That's because there's a shipping cost being added. The problem here is that the client doesn't know that, and the disclaimer at the bottom is misleading in this case since the shipping cost is already being considered.

2. Go to this [workspace](https://checkoutsummary--storecomponents.myvtex.com/) and add the same product to the cart. Now you should see a summary that looks like this:

![Screen Shot 2020-10-14 at 14 37 32](https://user-images.githubusercontent.com/27777263/96025141-1e51ec00-0e2b-11eb-87f0-63c05258d220.png)

This is now the default behavior, and the shipping cost is not taken into account.

3. Now go to this [workspace](https://checkoutsummary2--storecomponents.myvtex.com/) and add the same item to the cart. You should see a summary that looks like this:

![Screen Shot 2020-10-14 at 14 42 04](https://user-images.githubusercontent.com/27777263/96025398-7688ee00-0e2b-11eb-8700-a85782c8eeb6.png)

In this case, the `checkout-summary.compact` block is configured as:

```json
"checkout-summary.compact#minicart": {
    "children": ["summary-totalizers#minicart"],
    "props": {
      "totalizersToShow": ["Items", "Discounts", "Shipping"]
    }
  },
```

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/7NS9ubljEclMePHIOB/giphy.gif)
