### PR TITLE
Fix total showing as free when the cart can't be delivered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- When a cart cannot be delivered, it shows the total as "FREE". The fix checks if the cart is actually free or just can't be delivered.
+
 ## [0.17.0] - 2020-11-16
 ### Added
 - `totalCalculation` prop to `SummarySmall` component.

--- a/react/SummaryTotalizers.tsx
+++ b/react/SummaryTotalizers.tsx
@@ -37,6 +37,8 @@ function SummaryTotalizers({
     totalizers.push(shippingData)
   }
 
+  const orderHasNoValue = totalizers.length === 0
+
   return (
     <Fragment>
       {totalizers.map((totalizer) => (
@@ -46,15 +48,13 @@ function SummaryTotalizers({
           name={totalizer.id === 'CustomTax' ? totalizer.name : ''}
           value={totalizer.value}
           large={false}
-          totalizers
         />
       ))}
 
       {showTotal && (
         <SummaryItem
           label="Total"
-          totalizers={totalizers}
-          value={total || minTotalizerValue}
+          value={orderHasNoValue ? null : total || minTotalizerValue}
           large
         />
       )}

--- a/react/SummaryTotalizers.tsx
+++ b/react/SummaryTotalizers.tsx
@@ -46,11 +46,13 @@ function SummaryTotalizers({
           name={totalizer.id === 'CustomTax' ? totalizer.name : ''}
           value={totalizer.value}
           large={false}
+          totalizers
         />
       ))}
 
       {showTotal && (
-        <SummaryItem label="Total" value={total || minTotalizerValue} large />
+        
+        <SummaryItem label="Total" totalizers={totalizers} value={total || minTotalizerValue} large />
       )}
     </Fragment>
   )

--- a/react/SummaryTotalizers.tsx
+++ b/react/SummaryTotalizers.tsx
@@ -51,8 +51,12 @@ function SummaryTotalizers({
       ))}
 
       {showTotal && (
-        
-        <SummaryItem label="Total" totalizers={totalizers} value={total || minTotalizerValue} large />
+        <SummaryItem
+          label="Total"
+          totalizers={totalizers}
+          value={total || minTotalizerValue}
+          large
+        />
       )}
     </Fragment>
   )

--- a/react/components/SummaryItem.tsx
+++ b/react/components/SummaryItem.tsx
@@ -32,6 +32,7 @@ interface Props {
   label: string
   name?: string
   large: boolean
+  totalizers: any
   value: number | null
 }
 
@@ -41,10 +42,10 @@ const CSS_HANDLES = [
   'summaryItemPrice',
 ] as const
 
-function SummaryItem({ label, name, large, value }: Props) {
+function SummaryItem({ totalizers, label, name, large, value }: Props) {
   const handles = useCssHandles(CSS_HANDLES)
   const itemId = slugify(label)
-
+  
   return (
     <div
       className={`flex w-100 c-on-base lh-copy items-center ${
@@ -66,7 +67,7 @@ function SummaryItem({ label, name, large, value }: Props) {
           large ? 'fw6 fw5-l' : ''
         }`}
       >
-        <FormattedPrice value={value ? value / 100 : value} />
+        <FormattedPrice value={totalizers.length ? (value ? value / 100 : value) : null} />
       </div>
     </div>
   )

--- a/react/components/SummaryItem.tsx
+++ b/react/components/SummaryItem.tsx
@@ -4,7 +4,6 @@ import { FormattedPrice } from 'vtex.formatted-price'
 import { useCssHandles } from 'vtex.css-handles'
 
 import { slugify } from '../modules/slugify'
-import { Totalizer } from '../modules/types'
 
 defineMessages({
   Shipping: {
@@ -33,7 +32,6 @@ interface Props {
   label: string
   name?: string
   large: boolean
-  totalizers: Totalizer[]
   value: number | null
 }
 
@@ -43,7 +41,7 @@ const CSS_HANDLES = [
   'summaryItemPrice',
 ] as const
 
-function SummaryItem({ totalizers, label, name, large, value }: Props) {
+function SummaryItem({ label, name, large, value }: Props) {
   const handles = useCssHandles(CSS_HANDLES)
   const itemId = slugify(label)
 
@@ -68,9 +66,7 @@ function SummaryItem({ totalizers, label, name, large, value }: Props) {
           large ? 'fw6 fw5-l' : ''
         }`}
       >
-        <FormattedPrice
-          value={totalizers.length ? (value ? value / 100 : value) : null}
-        />
+        <FormattedPrice value={value ? value / 100 : value} />
       </div>
     </div>
   )

--- a/react/components/SummaryItem.tsx
+++ b/react/components/SummaryItem.tsx
@@ -4,6 +4,7 @@ import { FormattedPrice } from 'vtex.formatted-price'
 import { useCssHandles } from 'vtex.css-handles'
 
 import { slugify } from '../modules/slugify'
+import { Totalizer } from '../modules/types'
 
 defineMessages({
   Shipping: {
@@ -32,7 +33,7 @@ interface Props {
   label: string
   name?: string
   large: boolean
-  totalizers: any
+  totalizers: Totalizer[]
   value: number | null
 }
 
@@ -45,7 +46,7 @@ const CSS_HANDLES = [
 function SummaryItem({ totalizers, label, name, large, value }: Props) {
   const handles = useCssHandles(CSS_HANDLES)
   const itemId = slugify(label)
-  
+
   return (
     <div
       className={`flex w-100 c-on-base lh-copy items-center ${
@@ -67,7 +68,9 @@ function SummaryItem({ totalizers, label, name, large, value }: Props) {
           large ? 'fw6 fw5-l' : ''
         }`}
       >
-        <FormattedPrice value={totalizers.length ? (value ? value / 100 : value) : null} />
+        <FormattedPrice
+          value={totalizers.length ? (value ? value / 100 : value) : null}
+        />
       </div>
     </div>
   )


### PR DESCRIPTION
#### What problem is this solving?

When the items in the cart can't be delivered the Total shows the order as "Free". It happens because the `totalizers` is 0, so it's actually free. The fix simply check if the totalizers has a length, if yes the order is free, if not the order just can't be delivered. 

#### How to test it?

https://vysk--mambamag.myvtex.com/bottom-metal/p

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media.giphy.com/media/4PT6v3PQKG6Yg/source.gif)
