### PR TITLE
Feature/summary-installments block 

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -85,6 +85,12 @@ This app exports all of the following blocks. You can see more detailed informat
   },
   "summary-coupon": {
     // this block doesn't have any props
+  },
+  "summary-installments": {
+    "props": {
+      "message": "Up to {installmentsNumber}x {installmentValue}",
+      "markers": []
+    }
   }
 }
 ```
@@ -153,12 +159,39 @@ Id of the totalizers that should be displayed inside this component, e.g.:
 ]
 ```
 
+### SummaryInstallments
+The component rendered when used the `summary-installments` block. Renders the product installments. If more than one option is available, the one with the biggest number of installments will be displayed.
+
+#### Props
+
+| Prop name          | Type      |  Description | Default value |
+| --------------------| ----------|--------------|---------------|
+| `markers`           |`[string]` | IDs of your choosing to identify the block's rendered message and customize it using the admin's Site Editor. Learn how to use them accessing the documentation on [Using the Markers prop to customize a block's message](https://vtex.io/docs/recipes/style/using-the-markers-prop-to-customize-a-blocks-message). Notice the following: a block's message can also be customized in the Store Theme source code using the `message` prop. |`[]`|
+|  `blockClass`  |  `string`  |  Block  ID  of your choosing to  be  used  in [CSS  customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization#using-the-blockclass-property).  |  `undefined`  |
+|  `message`  |  `string`  |  Defines the block's default text i.e. the block message. You can also define which text message a block will render on the UI using the admin's Site Editor.  |  `undefined`  |
+
+#### Message variables
+| Message variables | Type | Description |
+| --- | --- | --- |
+| `installmentsNumber` | `string` | Number of installments. |
+| `installmentValue` | `string` | Value of each installment. |
+| `installmentsTotalValue` | `string` | Total value of installments. |
+| `interestRate` | `string` | Interest rate. |
+| `paymentSystemName` | `string` | Payment System of the installments. |
+| `hasInterest` | `boolean` | Whether the installments have interest (`true`) or not (`false`). |
+
 ## Customization
 
 In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).
 
 | CSS Handles              |
 | ------------------------ |
+| `installments`           |
+| `installmentsNumber`     |
+| `installmentValue`       |
+| `installmentsTotalValue` |
+| `interestRate`           |
+| `paymentSystemName`      |
 | `summaryTitle`           |
 | `summaryContent`         |
 | `summarySmallContent`    |

--- a/manifest.json
+++ b/manifest.json
@@ -23,7 +23,9 @@
     "vtex.formatted-price": "0.x",
     "vtex.flex-layout": "0.x",
     "vtex.css-handles": "0.x",
-    "vtex.store-drawer": "0.x"
+    "vtex.store-drawer": "0.x",
+    "vtex.native-types": "0.x",
+    "vtex.checkout-graphql": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -5,7 +5,10 @@
   "store/checkout-summary.Shipping": "Delivery",
   "store/checkout-summary.Summary": "Summary",
   "store/checkout-summary.Total": "Total",
-  "store/checkout-summary.disclaimer": "Shipping and taxes calculated at the Cart.",
+  "store/checkout-summary.disclaimer": "Shipping and taxes calculated in the Cart.",
   "admin/editor.checkout-summary.label": "Summary",
-  "admin/editor.checkout-summary.title": "Title"
+  "admin/editor.checkout-summary.title": "Title",
+  "store/checkout-summary.installments.default": "Up to {installmentsNumber}x {installmentValue}{hasInterest, select, true {, {interestRate} of interest} false { interest-free}}",
+  "admin/editor.checkout-summary.installments.description": "Values available for interpolation: '{installmentsNumber}, {installmentValue}, {installmentsTotalValue}, {interestRate}, {hasInterest}, {paymentSystemName}'",
+  "admin/editor.checkout-summary.installments.title": "Installments"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -5,7 +5,10 @@
   "store/checkout-summary.Shipping": "Entrega",
   "store/checkout-summary.Summary": "Resumen",
   "store/checkout-summary.Total": "Total",
-  "store/checkout-summary.disclaimer": "Gastos de envío e impuestos calculados al finalizar la compra.",
+  "store/checkout-summary.disclaimer": "Gastos de envío e impuestos calculados en el Carrito",
   "admin/editor.checkout-summary.label": "Resumen",
-  "admin/editor.checkout-summary.title": "Título"
+  "admin/editor.checkout-summary.title": "Título",
+  "store/checkout-summary.installments.default": "Hasta {installmentsNumber}x {installmentValue}{hasInterest, select, true {, {interestRate} de interés} false { sin interés}}",
+  "admin/editor.checkout-summary.installments.description": "Valores disponibles para interpolación: '{installmentsNumber}, {installmentValue}, {installmentsTotalValue}, {interestRate}, {hasInterest}, {paymentSystemName}'",
+  "admin/editor.checkout-summary.installments.title": "Cuotas"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -7,5 +7,8 @@
   "store/checkout-summary.Total": "Total",
   "store/checkout-summary.disclaimer": "Taxas e frete calculados no Carrinho",
   "admin/editor.checkout-summary.label": "Resumo",
-  "admin/editor.checkout-summary.title": "Título"
+  "admin/editor.checkout-summary.title": "Título",
+  "store/checkout-summary.installments.default": "Em até {installmentsNumber}x {installmentValue}{hasInterest, select, true {, {interestRate} de juros} false { sem juros}}",
+  "admin/editor.checkout-summary.installments.description": "Valores disponiveis para interpolação: '{installmentsNumber}, {installmentValue}, {installmentsTotalValue}, {interestRate}, {hasInterest}, {paymentSystemName}'",
+  "admin/editor.checkout-summary.installments.title": "Parcelamento"
 }

--- a/react/Summary.tsx
+++ b/react/Summary.tsx
@@ -2,6 +2,7 @@ import React, { PropsWithChildren } from 'react'
 import { defineMessages, FormattedMessage } from 'react-intl'
 import { useCssHandles } from 'vtex.css-handles'
 import { ExtensionPoint } from 'vtex.render-runtime'
+import { PaymentData } from 'vtex.checkout-graphql'
 
 import { Totalizer } from './modules/types'
 import SummaryContextProvider from './SummaryContext'
@@ -31,6 +32,7 @@ export interface SummaryProps {
   insertCoupon?: (coupon: string) => Promise<InsertCouponResult>
   loading?: boolean
   totalizers: Totalizer[]
+  paymentData: PaymentData
   total: number
 }
 
@@ -44,6 +46,7 @@ function Summary({
   coupon,
   insertCoupon,
   title,
+  paymentData,
 }: Props) {
   const handles = useCssHandles(CSS_HANDLES)
 
@@ -54,6 +57,7 @@ function Summary({
       loading={loading}
       totalizers={totalizers}
       total={total}
+      paymentData={paymentData}
     >
       {/* Removing the div below may break the layout. See PR #25 */}
       <div>

--- a/react/SummaryContext.tsx
+++ b/react/SummaryContext.tsx
@@ -21,6 +21,7 @@ function SummaryContextProvider({
   totalizers,
   total,
   children,
+  paymentData,
 }: PropsWithChildren<SummaryProps>) {
   return (
     <SummaryContext.Provider
@@ -30,6 +31,7 @@ function SummaryContextProvider({
         loading,
         totalizers,
         total,
+        paymentData,
       }}
     >
       {children}

--- a/react/SummaryInstallments.tsx
+++ b/react/SummaryInstallments.tsx
@@ -1,0 +1,134 @@
+import React from 'react'
+import { defineMessages, FormattedNumber } from 'react-intl'
+import { Installment, InstallmentOption } from 'vtex.checkout-graphql'
+import { useCssHandles } from 'vtex.css-handles'
+import { FormattedCurrency } from 'vtex.format-currency'
+import { IOMessageWithMarkers } from 'vtex.native-types'
+import { Loading } from 'vtex.render-runtime'
+
+import { useSummary } from './SummaryContext'
+
+const CSS_HANDLES = [
+  'installments',
+  'installmentsNumber',
+  'installmentValue',
+  'installmentsTotalValue',
+  'interestRate',
+  'paymentSystemName',
+] as const
+
+function SummaryInstallments(props: SummaryInstallmentsProps) {
+  const { loading, paymentData } = useSummary()
+  const { message, markers } = props
+  const handles = useCssHandles(CSS_HANDLES)
+
+  const { installmentOptions } = paymentData
+
+  if (loading) {
+    return <Loading />
+  }
+
+  if (!installmentOptions) {
+    return null
+  }
+
+  let maxInstallments: InstallmentOption | undefined
+
+  installmentOptions.forEach((installmentOption) => {
+    const currentValueIsEmpty =
+      !maxInstallments || Object.keys(maxInstallments).length === 0
+
+    if (
+      currentValueIsEmpty ||
+      installmentOption.installments.length >
+        (maxInstallments?.installments.length ?? 0)
+    ) {
+      maxInstallments = installmentOption
+    }
+  })
+
+  const maxInstallment: Installment | undefined =
+    maxInstallments?.installments[maxInstallments?.installments.length - 1]
+
+  const installmentsNumber = maxInstallment?.count
+  const installmentValue = maxInstallment?.value
+  const installmentsTotalValue = maxInstallment?.total
+  const interestRate = maxInstallment?.interestRate
+  const paymentSystemName = maxInstallments?.paymentSystem
+  const hasInterest = maxInstallment?.hasInterestRate
+
+  return (
+    <span className={handles.installments}>
+      <IOMessageWithMarkers
+        message={message}
+        markers={markers}
+        handleBase="installments"
+        values={{
+          installmentsNumber: (
+            <span
+              key="installmentsNumber"
+              className={handles.installmentsNumber}
+            >
+              {installmentsNumber && (
+                <FormattedNumber value={installmentsNumber} />
+              )}
+            </span>
+          ),
+          installmentValue: (
+            <span key="installmentValue" className={handles.installmentValue}>
+              {installmentValue && (
+                <FormattedCurrency value={installmentValue / 100} />
+              )}
+            </span>
+          ),
+          installmentsTotalValue: (
+            <span
+              key="installmentsTotalValue"
+              className={handles.installmentsTotalValue}
+            >
+              {installmentsTotalValue && (
+                <FormattedCurrency value={installmentsTotalValue / 100} />
+              )}
+            </span>
+          ),
+          interestRate: (
+            <span key="interestRate" className={handles.interestRate}>
+              {interestRate && (
+                <FormattedNumber value={interestRate} style="percent" />
+              )}
+            </span>
+          ),
+          paymentSystemName: (
+            <span key="paymentSystemName" className={handles.paymentSystemName}>
+              {paymentSystemName}
+            </span>
+          ),
+          hasInterest,
+        }}
+      />
+    </span>
+  )
+}
+
+const messages = defineMessages({
+  title: {
+    id: 'admin/editor.checkout-summary.installments.title',
+  },
+  description: {
+    id: 'admin/editor.checkout-summary.installments.description',
+  },
+  default: {
+    id: 'store/checkout-summary.installments.default',
+  },
+})
+
+SummaryInstallments.schema = {
+  title: messages.title.id,
+}
+
+interface SummaryInstallmentsProps {
+  message: string
+  markers: string[]
+}
+
+export default SummaryInstallments

--- a/react/SummarySmall.tsx
+++ b/react/SummarySmall.tsx
@@ -1,6 +1,7 @@
 import React, { PropsWithChildren } from 'react'
 import { FormattedMessage } from 'react-intl'
 import { useCssHandles } from 'vtex.css-handles'
+import { PaymentData } from 'vtex.checkout-graphql'
 
 import { Totalizer } from './modules/types'
 import SummaryContextProvider from './SummaryContext'
@@ -10,6 +11,7 @@ interface Props {
   total: number
   totalizersToShow?: string[]
   totalCalculation?: 'visibleTotalizers' | 'allTotalizers'
+  paymentData: PaymentData
 }
 
 const CSS_HANDLES = ['summarySmallContent', 'summarySmallDisclaimer'] as const
@@ -20,6 +22,7 @@ function SummarySmall({
   totalizers,
   totalizersToShow = ['Items'],
   totalCalculation = 'visibleTotalizers',
+  paymentData,
 }: PropsWithChildren<Props>) {
   const handles = useCssHandles(CSS_HANDLES)
 
@@ -40,6 +43,7 @@ function SummarySmall({
     <SummaryContextProvider
       totalizers={filteredTotalizers}
       total={totalToDisplay}
+      paymentData={paymentData}
     >
       <div className={`${handles.summarySmallContent} c-on-base`}>
         {children}

--- a/react/package.json
+++ b/react/package.json
@@ -26,15 +26,16 @@
     "apollo-client": "^2.5.1",
     "graphql": "^14.6.0",
     "typescript": "3.9.7",
+    "vtex.checkout-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.56.1/public/@types/vtex.checkout-graphql",
     "vtex.coupon": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.coupon@0.10.3/public/@types/vtex.coupon",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
-    "vtex.flex-layout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.15.1/public/@types/vtex.flex-layout",
-    "vtex.format-currency": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.2.0/public/@types/vtex.format-currency",
+    "vtex.flex-layout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.15.2/public/@types/vtex.flex-layout",
+    "vtex.format-currency": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.3.0/public/@types/vtex.format-currency",
     "vtex.formatted-price": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.formatted-price@0.4.0/public/@types/vtex.formatted-price",
     "vtex.order-coupon": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-coupon@0.7.1/public/@types/vtex.order-coupon",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.0/public/@types/vtex.render-runtime",
-    "vtex.store-drawer": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-drawer@0.14.0/public/@types/vtex.store-drawer",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.133.2/public/@types/vtex.styleguide"
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime",
+    "vtex.store-drawer": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-drawer@0.15.0/public/@types/vtex.store-drawer",
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.3/public/@types/vtex.styleguide"
   },
   "version": "0.18.0"
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5426,6 +5426,10 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+"vtex.checkout-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.56.1/public/@types/vtex.checkout-graphql":
+  version "0.56.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-graphql@0.56.1/public/@types/vtex.checkout-graphql#c1153ec5faf232f92abfe495f867019bfb7d510f"
+
 "vtex.coupon@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.coupon@0.10.3/public/@types/vtex.coupon":
   version "0.10.3"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.coupon@0.10.3/public/@types/vtex.coupon#7767726992b214455a83c5cf3c7b8d3db81c7fed"
@@ -5434,13 +5438,13 @@ verror@1.10.0:
   version "0.4.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles#8c45c6decf9acd2b944e07261686decff93d6422"
 
-"vtex.flex-layout@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.15.1/public/@types/vtex.flex-layout":
-  version "0.15.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.15.1/public/@types/vtex.flex-layout#b5e99e063dc79cf86c4a1167383e6661cfbc8e61"
+"vtex.flex-layout@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.15.2/public/@types/vtex.flex-layout":
+  version "0.15.2"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.15.2/public/@types/vtex.flex-layout#1b3e061cec4711dea3a0b98ce3d0434fdcca890b"
 
-"vtex.format-currency@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.2.0/public/@types/vtex.format-currency":
-  version "0.2.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.2.0/public/@types/vtex.format-currency#764e70df27af6a2e2b2a828c5870a5008b5ef28e"
+"vtex.format-currency@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.3.0/public/@types/vtex.format-currency":
+  version "0.3.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.format-currency@0.3.0/public/@types/vtex.format-currency#1cb7360452552301237c16d32037bbac61798f20"
 
 "vtex.formatted-price@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.formatted-price@0.4.0/public/@types/vtex.formatted-price":
   version "0.4.0"
@@ -5450,17 +5454,17 @@ verror@1.10.0:
   version "0.7.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-coupon@0.7.1/public/@types/vtex.order-coupon#6c09b44ce5c24dc65fc80a4298d62d3c476c6c52"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.0/public/@types/vtex.render-runtime":
-  version "8.126.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.0/public/@types/vtex.render-runtime#910cb26d40acb46be4d35d654948ae6a191d1057"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime":
+  version "8.126.11"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime#aceb734766093b56954ec19a074574b4c2c95242"
 
-"vtex.store-drawer@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-drawer@0.14.0/public/@types/vtex.store-drawer":
-  version "0.14.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-drawer@0.14.0/public/@types/vtex.store-drawer#a24567fa4e34a7488170398ce157b873f0ad69df"
+"vtex.store-drawer@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-drawer@0.15.0/public/@types/vtex.store-drawer":
+  version "0.15.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-drawer@0.15.0/public/@types/vtex.store-drawer#1fbf6e2f8cec7aa13ade2e7b7f2634a999aad505"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.133.2/public/@types/vtex.styleguide":
-  version "9.133.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.133.2/public/@types/vtex.styleguide#0b2020bfe4732e76f7dc6fcff4a77ba81f211c5d"
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.3/public/@types/vtex.styleguide":
+  version "9.135.3"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.3/public/@types/vtex.styleguide#744a8674d69a56594de969da36b263f94c9de66f"
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -7,6 +7,17 @@
           "default": "store/checkout-summary.Summary"
         }
       }
+    },
+    "SummaryInstallments": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "title": "admin/editor.checkout-summary.installments.title",
+          "description": "admin/editor.checkout-summary.installments.description",
+          "$ref": "app:vtex.native-types#/definitions/text",
+          "default": "store/checkout-summary.installments.default"
+        }
+      }
     }
   }
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -39,5 +39,11 @@
         "paragraph": false
       }
     }
+  },
+  "summary-installments": {
+    "component": "SummaryInstallments",
+    "content": {
+      "$ref": "app:vtex.checkout-summary#/definitions/SummaryInstallments"
+    }
   }
 }


### PR DESCRIPTION
#### What problem is this solving?

Creating block summary-installments to show installments related information. Similar to product-installments block from [product-price app](https://vtex.io/docs/components/all/vtex.product-price@1.10.0/).

#### How to test it?

Go to [workspace](https://installmentsminicart--tokstokio.myvtex.com/), add a product to cart and hover over minicart icon. The newly created block is located under the subtotal price.



#### Screenshots or example usage:

![](https://user-images.githubusercontent.com/34974565/100485803-3d0cf900-30e0-11eb-99f7-21968780848a.png)

#### Related to / Depends on

This feature depends on this https://github.com/vtex-apps/minicart/pull/281.


