### PR TITLE
Optional feature to display original items subtotal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Optional feature to display the original items subtotal (sum of list prices) in the same row as the items subtotal
+
 ## [0.22.0] - 2022-12-23
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,7 +63,7 @@ Therefore, in order to customize the Checkout Summary configuration, you can sim
 For more information on which props you need to pass to the Summary component, [see below](#components).
 
 This app exports all of the following blocks. You can see more detailed information of the
-`checkout-summary` and `checkout-summary.compact` blocks in the [Components](#components) section.
+`checkout-summary`, `checkout-summary.compact`, and `summary-totalizers` blocks in the [Components](#components) section.
 
 ```jsonc
 {
@@ -117,6 +117,20 @@ Notice the following: the block declared as children of the `drawer-trigger` blo
   }
 }
 ```
+
+## Components
+
+### SummaryTotalizers
+
+The component rendered when the `summary-totalizers` block is used.
+
+#### Props
+
+| Prop name           | Type      | Default | Description                                                                                      |
+| ------------------- | --------- | ------- | ------------------------------------------------------------------------------------------------ |
+| `showTotal`         | `boolean` | `true`  | Whether to display the overall order total                                                       |
+| `showDeliveryTotal` | `boolean` | `true`  | Whether to display the shipping/delivery total                                                   |
+| `showOriginalTotal` | `boolean` | `false` | Whether to display the original items value (sum of item list prices) next to the items subtotal |
 
 ### SummarySmall
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -80,7 +80,8 @@ This app exports all of the following blocks. You can see more detailed informat
   "summary-totalizers": {
     "props": {
       "showTotal": true,
-      "showDeliveryTotal": true
+      "showDeliveryTotal": true,
+      "showOriginalTotal": false
     }
   },
   "summary-coupon": {
@@ -151,7 +152,7 @@ Controls how the `Total` shown in the bottom of the summary is calculated. Possi
 Id of the totalizers that should be displayed inside this component, e.g.:
 
 ```js
-[
+;[
   // Value of the subtotal
   'Items',
   // Delivery value
@@ -160,45 +161,48 @@ Id of the totalizers that should be displayed inside this component, e.g.:
 ```
 
 ### SummaryInstallments
+
 The component rendered when used the `summary-installments` block. Renders the product installments. If more than one option is available, the one with the biggest number of installments will be displayed.
 
 #### Props
 
-| Prop name          | Type      |  Description | Default value |
-| --------------------| ----------|--------------|---------------|
-| `markers`           |`[string]` | IDs of your choosing to identify the block's rendered message and customize it using the admin's Site Editor. Learn how to use them accessing the documentation on [Using the Markers prop to customize a block's message](https://vtex.io/docs/recipes/style/using-the-markers-prop-to-customize-a-blocks-message). Notice the following: a block's message can also be customized in the Store Theme source code using the `message` prop. |`[]`|
-|  `blockClass`  |  `string`  |  Block  ID  of your choosing to  be  used  in [CSS  customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization#using-the-blockclass-property).  |  `undefined`  |
-|  `message`  |  `string`  |  Defines the block's default text i.e. the block message. You can also define which text message a block will render on the UI using the admin's Site Editor.  |  `undefined`  |
+| Prop name    | Type       | Description                                                                                                                                                                                                                                                                                                                                                                                                                                  | Default value |
+| ------------ | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `markers`    | `[string]` | IDs of your choosing to identify the block's rendered message and customize it using the admin's Site Editor. Learn how to use them accessing the documentation on [Using the Markers prop to customize a block's message](https://vtex.io/docs/recipes/style/using-the-markers-prop-to-customize-a-blocks-message). Notice the following: a block's message can also be customized in the Store Theme source code using the `message` prop. | `[]`          |
+| `blockClass` | `string`   | Block ID of your choosing to be used in [CSS customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization#using-the-blockclass-property).                                                                                                                                                                                                                                                                     | `undefined`   |
+| `message`    | `string`   | Defines the block's default text i.e. the block message. You can also define which text message a block will render on the UI using the admin's Site Editor.                                                                                                                                                                                                                                                                                 | `undefined`   |
 
 #### Message variables
-| Message variables | Type | Description |
-| --- | --- | --- |
-| `installmentsNumber` | `string` | Number of installments. |
-| `installmentValue` | `string` | Value of each installment. |
-| `installmentsTotalValue` | `string` | Total value of installments. |
-| `interestRate` | `string` | Interest rate. |
-| `paymentSystemName` | `string` | Payment System of the installments. |
-| `hasInterest` | `boolean` | Whether the installments have interest (`true`) or not (`false`). |
+
+| Message variables        | Type      | Description                                                       |
+| ------------------------ | --------- | ----------------------------------------------------------------- |
+| `installmentsNumber`     | `string`  | Number of installments.                                           |
+| `installmentValue`       | `string`  | Value of each installment.                                        |
+| `installmentsTotalValue` | `string`  | Total value of installments.                                      |
+| `interestRate`           | `string`  | Interest rate.                                                    |
+| `paymentSystemName`      | `string`  | Payment System of the installments.                               |
+| `hasInterest`            | `boolean` | Whether the installments have interest (`true`) or not (`false`). |
 
 ## Customization
 
 In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).
 
-| CSS Handles              |
-| ------------------------ |
-| `installments`           |
-| `installmentsNumber`     |
-| `installmentValue`       |
-| `installmentsTotalValue` |
-| `interestRate`           |
-| `paymentSystemName`      |
-| `summaryTitle`           |
-| `summaryContent`         |
-| `summarySmallContent`    |
-| `summarySmallDisclaimer` |
-| `summaryItemContainer`   |
-| `summaryItemLabel`       |
-| `summaryItemPrice`       |
+| CSS Handles                |
+| -------------------------- |
+| `installments`             |
+| `installmentsNumber`       |
+| `installmentValue`         |
+| `installmentsTotalValue`   |
+| `interestRate`             |
+| `paymentSystemName`        |
+| `summaryTitle`             |
+| `summaryContent`           |
+| `summarySmallContent`      |
+| `summarySmallDisclaimer`   |
+| `summaryItemContainer`     |
+| `summaryItemLabel`         |
+| `summaryItemPrice`         |
+| `summaryItemOriginalPrice` |
 
 ## Contributors ✨
 

--- a/react/Summary.tsx
+++ b/react/Summary.tsx
@@ -34,6 +34,7 @@ export interface SummaryProps {
   totalizers: Totalizer[]
   paymentData: PaymentData
   total: number
+  originalTotal?: number
 }
 
 type Props = PropsWithChildren<SummaryProps & SiteEditorSummaryProps>
@@ -43,6 +44,7 @@ function Summary({
   loading,
   totalizers,
   total,
+  originalTotal = 0,
   coupon,
   insertCoupon,
   title,
@@ -57,6 +59,7 @@ function Summary({
       loading={loading}
       totalizers={totalizers}
       total={total}
+      originalTotal={originalTotal}
       paymentData={paymentData}
     >
       {/* Removing the div below may break the layout. See PR #25 */}

--- a/react/SummaryContext.tsx
+++ b/react/SummaryContext.tsx
@@ -20,6 +20,7 @@ function SummaryContextProvider({
   loading,
   totalizers,
   total,
+  originalTotal,
   children,
   paymentData,
 }: PropsWithChildren<SummaryProps>) {
@@ -31,6 +32,7 @@ function SummaryContextProvider({
         loading,
         totalizers,
         total,
+        originalTotal,
         paymentData,
       }}
     >

--- a/react/SummarySmall.tsx
+++ b/react/SummarySmall.tsx
@@ -9,6 +9,7 @@ import SummaryContextProvider from './SummaryContext'
 interface Props {
   totalizers: Totalizer[]
   total: number
+  originalTotal?: number
   totalizersToShow?: string[]
   totalCalculation?: 'visibleTotalizers' | 'allTotalizers'
   paymentData: PaymentData
@@ -18,6 +19,7 @@ const CSS_HANDLES = ['summarySmallContent', 'summarySmallDisclaimer'] as const
 
 function SummarySmall({
   total,
+  originalTotal = 0,
   children,
   totalizers,
   totalizersToShow = ['Items'],
@@ -43,6 +45,7 @@ function SummarySmall({
     <SummaryContextProvider
       totalizers={filteredTotalizers}
       total={totalToDisplay}
+      originalTotal={originalTotal}
       paymentData={paymentData}
     >
       <div className={`${handles.summarySmallContent} c-on-base`}>

--- a/react/SummaryTotalizers.tsx
+++ b/react/SummaryTotalizers.tsx
@@ -21,13 +21,15 @@ const isShippingPresent = (totalizers: Totalizer[]) => {
 interface Props {
   showTotal?: boolean
   showDeliveryTotal?: boolean
+  showOriginalTotal?: boolean
 }
 
 function SummaryTotalizers({
   showTotal = true,
   showDeliveryTotal = true,
+  showOriginalTotal = false,
 }: Props) {
-  const { loading, totalizers, total } = useSummary()
+  const { loading, totalizers, total, originalTotal } = useSummary()
 
   if (loading) {
     return <Loading />
@@ -47,6 +49,7 @@ function SummaryTotalizers({
           label={totalizer.id}
           name={totalizer.id === 'CustomTax' ? totalizer.name : ''}
           value={totalizer.value}
+          originalValue={showOriginalTotal ? originalTotal : 0}
           large={false}
         />
       ))}

--- a/react/components/SummaryItem.tsx
+++ b/react/components/SummaryItem.tsx
@@ -33,15 +33,17 @@ interface Props {
   name?: string
   large: boolean
   value: number | null
+  originalValue?: number
 }
 
 const CSS_HANDLES = [
   'summaryItemContainer',
   'summaryItemLabel',
   'summaryItemPrice',
+  'summaryItemOriginalPrice',
 ] as const
 
-function SummaryItem({ label, name, large, value }: Props) {
+function SummaryItem({ label, name, large, value, originalValue = 0 }: Props) {
   const handles = useCssHandles(CSS_HANDLES)
   const itemId = slugify(label)
 
@@ -60,6 +62,16 @@ function SummaryItem({ label, name, large, value }: Props) {
             <FormattedMessage id={`store/checkout-summary.${label}`} />
           ))}
       </div>
+      {itemId === 'items' && value && originalValue > value && (
+        <div
+          id="original-items-price"
+          className={`flex-auto tr c-danger strike ${
+            handles.summaryItemOriginalPrice
+          } ${large ? 'fw6 fw5-l' : ''}`}
+        >
+          <FormattedPrice value={originalValue / 100} />
+        </div>
+      )}
       <div
         id={`${itemId}-price`}
         className={`flex-auto tr ${handles.summaryItemPrice} ${


### PR DESCRIPTION
#### What problem is this solving?

See https://github.com/vtex-apps/minicart/pull/324 for context.

This PR allows a store to optionally display the "original items total" (i.e. sum of items' list prices) as a striked-out value next to the existing items subtotal in the checkout summary. This behavior can be enabled by setting a `showOriginalTotal` prop on the `summary-totalizers` block. If the prop is not set, the new content will not be rendered. Additionally, the new content will not be rendered if the sum of the list prices is the same as the sum of the selling prices. Here's how the new content looks when rendered:
 
![image](https://user-images.githubusercontent.com/6306265/210882341-ccc01612-03fd-4e35-a58f-1de437540d63.png)

#### How to test it?

Linked here: https://minicartsubtotal--beautycounterqa.myvtex.com/nourishing-eye-cream/p